### PR TITLE
date_to_week fix

### DIFF
--- a/lib/espn_scraper/date_to_week.rb
+++ b/lib/espn_scraper/date_to_week.rb
@@ -16,7 +16,7 @@ module ESPN
     def uri
       http_params = %W[ seasonYear=#{self.date.year} seasonType=2 weekNumber=#{closest_game_week} confId=80 ]
 
-      "scores/#{self.league}/scoreboard?#{http_params.join('&')}"
+      "#{self.league}/scoreboard?#{http_params.join('&')}"
     end
 
     def closest_game_week


### PR DESCRIPTION
I was getting this error:

`The url http://espn.go.com from the path ["scores/nfl/scoreboard?seasonYear=2015&seasonType=2&weekNumber=1&confId=80"] did not return a valid page.`

The proposed change fixed my error.